### PR TITLE
Use recentchanges table instead of revision table

### DIFF
--- a/public_html/runbot.php
+++ b/public_html/runbot.php
@@ -28,7 +28,7 @@ function getEditCounts( $link, $source, $days = 3, $limit = 5, $method = 'catego
 		} else {
 			$subquery = "select a.page_id,a.page_title from categorylinks join page as t on t.page_id=cl_from and t.page_namespace=1 join page as a on a.page_title=t.page_title and a.page_namespace=0 where cl_to='".$source."' and a.page_latest>".$revId;
 		}
-		$result = mysqli_query($link, "select main.page_title as title,count(main.rev_minor_edit) as ctall, sum(main.rev_minor_edit) from (select tt.page_title,rev_minor_edit,rev_user_text from revision join (".$subquery.") as tt on rev_page=tt.page_id where rev_timestamp>".$revTimestamp.") as main group by main.page_title order by ctall desc limit ".$limit.";");
+		$result = mysqli_query($link, "select main.page_title as title,count(main.rc_minor) as ctall, sum(main.rc_minor) from (select tt.page_title,rc_minor,rc_user_text from recentchanges join (".$subquery.") as tt on rc_cur_id=tt.page_id where rc_timestamp>".$revTimestamp.") as main group by main.page_title order by ctall desc limit ".$limit.";");
 		while ( $row = mysqli_fetch_array( $result ) ) {
 			$title = str_replace( '_', ' ', $row['title'] );
 			$pages[$title] = $row['ctall'];


### PR DESCRIPTION
We do not need to analyze the entire revision table when we can use the much smaller and more relevant recentchanges table.
